### PR TITLE
Add onboarding

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,28 @@
+# Privacy Policy
+
+## Complete Privacy Guarantee
+
+StoryFriends is designed with privacy as our top priority. **Your data never leaves your device.**
+
+## What We Do
+
+- **100% Local Processing**: All AI conversations happen on your device using a local language model
+- **Local Storage Only**: Chat messages are stored locally using Apple's SwiftData framework
+- **No Internet Required**: Core functionality works completely offline
+
+## What We Don't Do
+
+- ❌ Send data to external servers or AI services
+- ❌ Collect personal information, analytics, or usage data
+- ❌ Use cloud storage or external databases
+- ❌ Track your behavior or require accounts
+
+## Data We Store Locally
+
+- Chat messages and timestamps
+- Selected AI persona
+- All data remains encrypted on your device
+
+---
+
+_Your privacy is guaranteed by design. All conversations remain truly private._

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -23,6 +23,12 @@ StoryFriends is designed with privacy as our top priority. **Your data never lea
 - Selected AI persona
 - All data remains encrypted on your device
 
+## Acknowledgements
+
+This app uses Google's **Gemma 3 1B Instruct** model for local AI processing. The model is licensed under the Gemma Terms of Use and runs entirely on your device.
+
+For more information about the Gemma model, visit: https://ai.google.dev/gemma
+
 ---
 
 _Your privacy is guaranteed by design. All conversations remain truly private._

--- a/PersonaChat/Models/DataSchema.swift
+++ b/PersonaChat/Models/DataSchema.swift
@@ -30,6 +30,25 @@ enum DataSchema: VersionedSchema {
             self.text = text
             self.role = role
         }
+
+        static var onboarding: String {
+                """
+                Welcome to PersonaChat! 🎉
+                
+                I'm your magical storytelling companion. Choose from different personas, each with their own unique personality and style:
+                
+                🧚‍♀️ **Luna** - A whimsical fairy who sprinkles wonder and cheer
+                🛡️ **Sir Gallop** - A brave knight ready for kind quests
+                🐒 **Bananas** - A silly monkey who loves giggles and fun
+                🧜🏼‍♀️ **Aqua** - A calm mermaid guide to ocean adventures
+                🤖 **Gizmo** - An upbeat robot inventor who loves to tinker
+                🐱 **Whiskers** - A curious kitten ready to explore
+                
+                Simply type your message and I'll create an interactive story just for you! You can switch between personas anytime using the menu above.
+                
+                Ready to begin your adventure? Just tell me what kind of story you'd like to hear! ✨
+                """
+        }
     }
 
 
@@ -41,3 +60,5 @@ enum MessageRole: String, Codable {
     case user
     case bot
 }
+
+let CURRENT_ONBOARDING_VERSION = "1.0"

--- a/PersonaChat/Views/ChatView.swift
+++ b/PersonaChat/Views/ChatView.swift
@@ -34,9 +34,6 @@ struct ChatView: View {
     private var bot: Bot?
 
     @State
-    private var showError = false
-
-    @State
     private var textFieldHeight: CGFloat = 0
 
     @State
@@ -128,7 +125,6 @@ struct ChatView: View {
                 bot = try! .init(context: modelContext)
             }
         }
-        .alert("Error responding", isPresented: $showError) {}
         .navigationTitle(selectedPersona.emoji + " " + selectedPersona.name)
         .toolbarTitleMenu {
             Picker("Persona", selection: $selectedPersonaID) {
@@ -199,7 +195,8 @@ struct ChatView: View {
                         history: messages
                     )
                 } catch {
-                    showError = true
+                    response.text += ".. Oops, something went wrong!"
+                    try? self.modelContext.save()
                 }
             }
         }

--- a/PersonaChat/Views/ChatView.swift
+++ b/PersonaChat/Views/ChatView.swift
@@ -46,133 +46,171 @@ struct ChatView: View {
 
     @State
     private var scrollTrigger: Int = 0
+    
+    @State
+    private var hapticTrigger: Int = 0
 
     var body: some View {
+        mainContent
+            .background(backgroundView)
+            .onChange(of: selectedPersonaID) {
+                clearChat()
+                bot?.set(persona: selectedPersona)
+            }
+            .navigationTitle(selectedPersona.emoji + " " + selectedPersona.name)
+            .toolbarTitleMenu { personaPicker }
+            .toolbar { toolbarContent }
+            .toolbarTitleDisplayMode(.inline)
+            .font(.custom(selectedPersona.fontName, size: 18, relativeTo: .body))
+            .onChange(of: isTextFieldFocused) { _, isFocused in
+                handleTextFieldFocus(isFocused)
+            }
+            .sensoryFeedback(.impact(weight: .light), trigger: hapticTrigger)
+    }
+    
+    private var mainContent: some View {
         ZStack {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
-                        ForEach(messages) { message in
-                            MessageRow(message)
-                                .tag(message.id)
-                        }
+            chatScrollView
+            inputArea
+        }
+    }
+    
+    private var chatScrollView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(messages) { message in
+                        MessageRow(message)
+                            .tag(message.id)
                     }
-                    .padding(.bottom, textFieldHeight + 20) // Dynamic padding based on text field height + some extra space
                 }
+                .padding(.bottom, textFieldHeight + 20)
+            }
+            .onAppear {
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: messages.count) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: bot?.isGenerating) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: textFieldHeight) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: scrollTrigger) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .task {
+                await handleTask(proxy: proxy)
+            }
+        }
+    }
+    
+    private var inputArea: some View {
+        VStack {
+            Spacer()
+            inputField
+        }
+    }
+    
+    private var inputField: some View {
+        HStack {
+            TextField("Type a message...", text: $text)
+                .onSubmit(addMessage)
+                .focused($isTextFieldFocused)
+                .submitLabel(.send)
+                .textFieldStyle(.plain)
+                .disabled((bot?.isGenerating ?? false))
+
+            if bot?.isGenerating == true {
+                Button("Stop", systemImage: "square.fill") {
+                    bot?.stop()
+                }.labelStyle(.iconOnly)
+            }
+        }
+        .padding()
+        .background(.ultraThinMaterial)
+        .clipShape(.rect(cornerRadius: 20))
+        .padding()
+        .background(textFieldHeightReader)
+    }
+    
+    private var textFieldHeightReader: some View {
+        GeometryReader { geometry in
+            Color.clear
                 .onAppear {
-                    scrollToBottom(proxy: proxy)
+                    textFieldHeight = geometry.size.height
                 }
-                .onChange(of: messages.count) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: bot?.isGenerating) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: textFieldHeight) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: scrollTrigger) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .task {
-                    // lazy init once we have a ModelContext in scope
-                    if bot == nil {
-                        bot = try! .init(context: modelContext)
-                    }
-
-                    // Show onboarding message with typing simulation
-                    if shouldShowOnboarding {
-                        await showOnboardingWithTyping()
-                        scrollToBottom(proxy: proxy)
+                .onChange(of: geometry.size.height) { _, newHeight in
+                    if newHeight > 0 {
+                        textFieldHeight = newHeight
                     }
                 }
-            }
-
-            VStack {
-                Spacer()
-
-                HStack {
-                    TextField("Type a message...", text: $text)
-                        .onSubmit(addMessage)
-                        .focused($isTextFieldFocused)
-                        .submitLabel(.send)
-                        .textFieldStyle(.plain)
-                        .disabled((bot?.isGenerating ?? false))
-
-                    if bot?.isGenerating == true {
-                        Button("Stop", systemImage: "square.fill") {
-                            bot?.stop()
-                        }.labelStyle(.iconOnly)
-                    }
-                }
-                .padding()
-                .background(.ultraThinMaterial)
-                .clipShape(.rect(cornerRadius: 20))
-                .padding()
-                .background(
-                    GeometryReader { geometry in
-                        Color.clear
-                            .onAppear {
-                                textFieldHeight = geometry.size.height
-                            }
-                            .onChange(of: geometry.size.height) { _, newHeight in
-                                if newHeight > 0 {
-                                    textFieldHeight = newHeight
-                                }
-                            }
-                    }
-                )
+        }
+    }
+    
+    private var backgroundView: some View {
+        ZStack {
+            Image(selectedPersona.backgroundImage)
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
+            Rectangle()
+                .fill(.ultraThickMaterial.opacity(0.95))
+                .ignoresSafeArea()
+        }
+    }
+    
+    private var personaPicker: some View {
+        Picker("Persona", selection: $selectedPersonaID) {
+            ForEach(PERSONAS, id: \.id) { persona in
+                Text("\(persona.emoji)  \(persona.name)")
+                    .tag(persona.id)
             }
         }
-        .background(
-            ZStack {
-                Image(selectedPersona.backgroundImage)
-                    .resizable()
-                    .scaledToFill()
-                    .ignoresSafeArea()
-                Rectangle()
-                    .fill(.ultraThickMaterial.opacity(0.95))
-                    .ignoresSafeArea()
-            }
-        )
-        .onChange(of: selectedPersonaID) {
-            clearChat()
-            bot?.set(persona: selectedPersona)
-        }
-        .navigationTitle(selectedPersona.emoji + " " + selectedPersona.name)
-        .toolbarTitleMenu {
+    }
+    
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+#if os(macOS)
+        ToolbarItem {
             Picker("Persona", selection: $selectedPersonaID) {
                 ForEach(PERSONAS, id: \.id) { persona in
                     Text("\(persona.emoji)  \(persona.name)")
+                        .font(persona.font)
                         .tag(persona.id)
                 }
             }
+            .pickerStyle(.menu)
         }
-        .toolbar {
-#if os(macOS)
-            ToolbarItem {
-                Picker("Persona", selection: $selectedPersonaID) {
-                    ForEach(PERSONAS, id: \.id) { persona in
-                        Text("\(persona.emoji)  \(persona.name)")
-                            .font(persona.font)
-                            .tag(persona.id)
-                    }
-                }
-                .pickerStyle(.menu)
-            }
 #endif
-            ToolbarItem {
-                Button("Clear Chat", systemImage: "square.and.pencil", action: clearChat)
+        ToolbarItem {
+            Button("Clear Chat", systemImage: "square.and.pencil", action: clearChat)
+        }
+    }
+    
+    @MainActor
+    private func handleTask(proxy: ScrollViewProxy) async {
+        // lazy init once we have a ModelContext in scope
+        if bot == nil {
+            bot = try! .init(context: modelContext) {
+                hapticTrigger += 1
             }
         }
-        .toolbarTitleDisplayMode(.inline)
-        .font(.custom(selectedPersona.fontName, size: 18, relativeTo: .body))
-        .onChange(of: isTextFieldFocused) { _, isFocused in
-            guard isFocused else { return }
-            // Scroll to bottom when text field is focused
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                scrollTrigger += 1
-            }
+
+        // Show onboarding message with typing simulation
+        if shouldShowOnboarding {
+            await showOnboardingWithTyping()
+            scrollToBottom(proxy: proxy)
+        }
+    }
+    
+    private func handleTextFieldFocus(_ isFocused: Bool) {
+        guard isFocused else { return }
+        // Scroll to bottom when text field is focused
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            scrollTrigger += 1
         }
     }
     
@@ -189,8 +227,8 @@ struct ChatView: View {
             onboardingMessage.text = String(fullText.prefix(i))
             try? modelContext.save()
             
-            // Scroll to bottom during typing
             scrollTrigger += 1
+            hapticTrigger += 1
             
             // Vary typing speed for more realistic effect
             let delay = fullText[fullText.index(fullText.startIndex, offsetBy: min(i, fullText.count - 1))] == " " ? 0.05 : 0.03
@@ -224,7 +262,9 @@ struct ChatView: View {
                 isTextFieldFocused = true
             } catch {
 
-                bot = try? .init(context: modelContext)
+                bot = try? .init(context: modelContext) {
+                    hapticTrigger += 1
+                }
 
                 do {
                     try await bot?.ask(

--- a/PersonaChat/Views/MaybeMarkdown.swift
+++ b/PersonaChat/Views/MaybeMarkdown.swift
@@ -14,8 +14,11 @@ struct MaybeMarkdown: View {
         self.txt = txt
     }
     var body: some View {
-        if let md = try? AttributedString(markdown: txt) {
-            Text(md)
+        if let attributedString = try? AttributedString(
+            markdown: txt,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            Text(attributedString)
         } else {
             Text(txt)
         }
@@ -23,5 +26,9 @@ struct MaybeMarkdown: View {
 }
 
 #Preview {
-    MaybeMarkdown("~Hey~ _there_, **world!**")
+    MaybeMarkdown("""
+~Hey~
+_there_,
+**world!**
+""")
 }

--- a/PersonaChat/Views/MessageRow.swift
+++ b/PersonaChat/Views/MessageRow.swift
@@ -26,12 +26,12 @@ struct MessageRow: View {
             }
             .padding()
         } else {
-            if #available(iOS 26.0, *) {
-                Text(message.text)
+            if #available(iOS 26.0, macOS 26.0, *) {
+                MaybeMarkdown(message.text)
                     .padding(.horizontal)
                     .lineHeight(.loose)
             } else {
-                Text(message.text)
+                MaybeMarkdown(message.text)
                     .padding(.horizontal)
             }
         }


### PR DESCRIPTION
This pull request introduces several user experience and privacy improvements to the PersonaChat app. The most notable changes include a new privacy policy, an onboarding message with simulated typing and haptic feedback, and enhancements to markdown rendering. These updates aim to make the app more welcoming for new users, provide clear privacy guarantees, and improve message display.

**Privacy and onboarding improvements:**

* Added a new `PRIVACY.md` file outlining a complete privacy guarantee: all data and AI processing are local, with no external servers or data collection.
* Implemented an onboarding message shown to new users, featuring persona introductions and instructions. The message is displayed only once per version and uses simulated typing with haptic feedback for a welcoming experience (`DataSchema.swift`, onboarding logic in `ChatView.swift`). [[1]](diffhunk://#diff-5da527b1b378af25f72f7a965c0a58eda5af87d8ccbf08d4b7d5a034f20123c5R33-R51) [[2]](diffhunk://#diff-5da527b1b378af25f72f7a965c0a58eda5af87d8ccbf08d4b7d5a034f20123c5R63-R64) [[3]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbR29-R78) [[4]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbL158-R238)

**User experience enhancements:**

* Added periodic haptic feedback during bot responses and onboarding message typing to create a more interactive feel (`Bot.swift`, `ChatView.swift`). [[1]](diffhunk://#diff-64b8f70b713ff82bfbd497fa3197a0e216403225a39cc2d059c58d408f95fddaR23-R25) [[2]](diffhunk://#diff-64b8f70b713ff82bfbd497fa3197a0e216403225a39cc2d059c58d408f95fddaR40) [[3]](diffhunk://#diff-64b8f70b713ff82bfbd497fa3197a0e216403225a39cc2d059c58d408f95fddaR70-R83) [[4]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbR29-R78) [[5]](diffhunk://#diff-89dce2ef71a40254bc3dd00963f8715245524ecbde8c20a0f11d73686a4f77fbL158-R238)
* Improved markdown rendering in bot messages by using inline-only syntax and updating message display to consistently use markdown (`MaybeMarkdown.swift`, `MessageRow.swift`). [[1]](diffhunk://#diff-4b31cf935c0021bf426b1b2168f9bcbd837584d7565c0876fe11a00a6248484aL17-R33) [[2]](diffhunk://#diff-a819d793f99baa9981c077ad4cd10ebfc12e5aeef94259441231760a22e089d2L29-R34)

**Error handling:**

* Enhanced error handling in chat: if bot response fails, a friendly error message is appended to the chat instead of showing a modal alert (`ChatView.swift`).